### PR TITLE
Jupyterlite notebooks handle external URLS

### DIFF
--- a/hw/hw02/hw02.ipynb
+++ b/hw/hw02/hw02.ipynb
@@ -424,7 +424,7 @@
    },
    "outputs": [],
    "source": [
-    "president_birth_years = Table.read_table(\"Table.read_table('https://www.data8.org/materials-sp22-assets/hw/hw02/president_births.csv\").column('Birth Year')\n",
+    "president_birth_years = Table.read_table(\"https://www.data8.org/materials-sp22-assets/hw/hw02/president_births.csv\").column('Birth Year')\n",
     "\n",
     "most_recent_birth_year = ...\n",
     "most_recent_birth_year"
@@ -645,7 +645,7 @@
    },
    "outputs": [],
    "source": [
-    "max_temperatures = Table.read_table(\"Table.read_table('https://www.data8.org/materials-sp22-assets/hw/hw02/temperatures.csv\").column(\"Daily Max Temperature\")\n",
+    "max_temperatures = Table.read_table(\"https://www.data8.org/materials-sp22-assets/hw/hw02/temperatures.csv\").column(\"Daily Max Temperature\")\n",
     "\n",
     "celsius_max_temperatures = ...\n",
     "celsius_max_temperatures"
@@ -690,7 +690,7 @@
    },
    "outputs": [],
    "source": [
-    "min_temperatures = Table.read_table(\"Table.read_table('https://www.data8.org/materials-sp22-assets/hw/hw02/temperatures.csv\").column(\"Daily Min Temperature\")\n",
+    "min_temperatures = Table.read_table(\"https://www.data8.org/materials-sp22-assets/hw/hw02/temperatures.csv\").column(\"Daily Min Temperature\")\n",
     "\n",
     "celsius_temperature_ranges = ...\n",
     "celsius_temperature_ranges"
@@ -972,6 +972,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "477e7bcb",
    "metadata": {},


### PR DESCRIPTION
- moved external files to materials-sp22-assets
- CORS issue is resolved by moving external assets to the materials-sp22-assets